### PR TITLE
Fix a bug in configOption

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,16 +31,16 @@ func configOption[T configOptionValue](key string) T {
 	cKey := newCString(key)
 	defer freeCString(cKey)
 
-	t := any(new(T))
+	var t T
 	var result any
 
-	switch t.(type) {
+	switch any(t).(type) {
 	case float64:
-		result = C.config_getFloat(cKey)
+		result = float64(C.config_getFloat(cKey))
 	case int:
-		result = C.config_getInt(cKey)
+		result = int(C.config_getInt(cKey))
 	case bool:
-		result = C.config_getBool(cKey)
+		result = bool(C.config_getBool(cKey) > 0)
 	}
 
 	return result.(T)


### PR DESCRIPTION
Fixed a bug in configOption that yielded `interface conversion: interface {} is nil, not int` when executing any of the config getter functions.
It appeared not to check the type of `T` properly and fail to match any case in the switch.
I fixed that and also made it cast from CTypes to go types.

The error is now gone, I can now execute `MaxPlayers` and other getters properly. The problem could be an issue with my cgo setup tho. Please check if the commit works on your side.
`gcc -v`: `gcc version 8.1.0 (i686-win32-dwarf-rev0, Built by MinGW-W64 project) `

Also, I think `SetConfigOption` and `ConfigOption` should be exposed in the package for free use in gamemodes as the config is useful for storing secrets.